### PR TITLE
Fixed whitespace-only message submission in chat interface.

### DIFF
--- a/src/devtools/App.tsx
+++ b/src/devtools/App.tsx
@@ -423,7 +423,7 @@ function MessageInput(props: {
         if (event) {
             event.preventDefault()
         }
-        if (messageInput.length === 0) {
+        if (messageInput.trim().length === 0) {
             return
         }
         props.onSubmit(createMessage('user', messageInput))


### PR DESCRIPTION
Code before and after 

<img width="624" height="154" alt="Code Before and Afer" src="https://github.com/user-attachments/assets/58237447-5981-416c-8f5d-73e5de8bc3e9" />

Explanation: The issue was to fix a bug where users could submit empty lines, tabs, or spaces and that often could clutter the chat with empty lines. The fix for this was to use the .trim() function and to check and make sure that the line has more than just spaces in it.

Video Link:
https://drive.google.com/file/d/1wRqOzvphkC-7EyXfP0KX27KM4mU3fW0P/view?usp=sharing 