### PR TITLE
Add copy button

### DIFF
--- a/src/devtools/App.css
+++ b/src/devtools/App.css
@@ -1,3 +1,95 @@
 .App {
   text-align: center;
 }
+
+/* Code block copy button styles */
+.code-block-container {
+  position: relative;
+  display: inline-block;
+  width: 100%;
+}
+
+.code-block-container:hover .copy-button {
+  opacity: 1;
+  visibility: visible;
+}
+
+.copy-button {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 8px;
+  background: rgba(0, 0, 0, 0.8);
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 500;
+  opacity: 0;
+  visibility: hidden;
+  transition: all 0.2s ease-in-out;
+  backdrop-filter: blur(4px);
+}
+
+.copy-button:hover {
+  background: rgba(0, 0, 0, 0.9);
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+.copy-button:active {
+  transform: translateY(0);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+}
+
+.copy-button.copied {
+  background: #4caf50;
+  color: white;
+}
+
+.copy-button.copied:hover {
+  background: #45a049;
+}
+
+.copy-button svg {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+.copy-text {
+  white-space: nowrap;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
+}
+
+/* Ensure code blocks have proper positioning context */
+.code-block-container pre {
+  margin: 0;
+  position: relative;
+}
+
+/* Dark theme support */
+@media (prefers-color-scheme: dark) {
+  .copy-button {
+    background: rgba(255, 255, 255, 0.9);
+    color: black;
+  }
+  
+  .copy-button:hover {
+    background: rgba(255, 255, 255, 0.95);
+  }
+  
+  .copy-button.copied {
+    background: #4caf50;
+    color: white;
+  }
+  
+  .copy-button.copied:hover {
+    background: #45a049;
+  }
+}

--- a/src/devtools/App.tsx
+++ b/src/devtools/App.tsx
@@ -423,7 +423,7 @@ function MessageInput(props: {
         if (event) {
             event.preventDefault()
         }
-        if (messageInput.length === 0) {
+        if (messageInput.trim().length === 0) {
             return
         }
         props.onSubmit(createMessage('user', messageInput))


### PR DESCRIPTION
Code Before 
<img width="624" height="390" alt="Chatbox Issue 2 Before1" src="https://github.com/user-attachments/assets/112f1044-79fb-4892-9b0b-479e6e797093" />
<img width="624" height="417" alt="Chatbox Issue 2 Before 2" src="https://github.com/user-attachments/assets/6e9a5763-a94c-4f7b-bc4f-73644f9c304b" />

Code After
<img width="624" height="331" alt="Chatbox Issue 2 After 1" src="https://github.com/user-attachments/assets/352e065e-0a6e-4c07-be80-b2e75613ba40" />
<img width="624" height="337" alt="Chatbox Issue 2 After 2" src="https://github.com/user-attachments/assets/1b3f9cab-e23e-4024-9ec1-8b552db230b2" />

Explanation: The feature that we wanted to implement was a way for users to easily copy code from code blocks without needed to manually do that. The solution was to add a copy button that appears when you hover over the code blocks and show that the code was copied when pushed. 

Video Link:
https://drive.google.com/file/d/15TBhhKNe9cnhbo-Ju3ogBtNyXLELYuyh/view?usp=sharing 